### PR TITLE
Update errata link for Navy Reprisal card

### DIFF
--- a/content/errata/arcs/en-US.yml
+++ b/content/errata/arcs/en-US.yml
@@ -2,7 +2,7 @@
     - text: 'To clarify how it interacts with other card abilities, the *Callow* ability should read: “You cannot **tax** cities that you do not control.”'
   card: Upstart
 - errata:
-    - text: "This card is misprinted as an event card in the first printing of Arcs: The Blighted Reach Expansion.  (Updated in Blighted Reach 2nd Printing and the Blighted Reach Errata Pack. The Errata Pack is available [here](https://buriedgiantstudios.com/products/blighted-reach-campaign-expansion-errata-card-pack?_pos=6&_sid=45a094aeb&_ss=r))"
+    - text: "This card is misprinted as an event card in the first printing of Arcs: The Blighted Reach Expansion.  (Updated in Blighted Reach 2nd Printing and the Blighted Reach Errata Pack. The Errata Pack is available [here](https://buriedgiant.shop/products/arcs-the-blighted-reach-errata-pack))"
   card: Navy Reprisal
 - errata:
     - text: "The term 'blockaded' present in the first-printing clarification is an old term for 'controlled by anything other than you.' In the base game, all that matters is Rival control. In the campaign, this can include control by the Empire, etc."


### PR DESCRIPTION
The old link didn't work for me. I've added the link to the buried giant shop that seems to work